### PR TITLE
feat: add extraction modes and timestamp fields

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -1,0 +1,32 @@
+name: Rake
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Test CLI help command
+        run: bundle exec script/extract-locks.rb help
+
+      - name: Test CLI list command
+        run: bundle exec script/extract-locks.rb list
+
+      - name: Test extraction with 3 containers (verify index.yaml generation)
+        run: bundle exec script/extract-locks.rb test

--- a/.github/workflows/update-locks.yml
+++ b/.github/workflows/update-locks.yml
@@ -4,7 +4,21 @@ on:
   schedule:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Extraction mode'
+        required: false
+        default: 'incremental'
+        type: choice
+        options:
+          - incremental
+          - replace
+          - revamp
+      version:
+        description: 'Version to replace (required for replace mode)'
+        required: false
+        type: string
 
 # Concurrency: only allow one run at a time, cancel in-progress runs
 concurrency:
@@ -21,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - name: List available versions on Docker Hub
@@ -34,11 +48,26 @@ jobs:
           echo "Available versions on Docker Hub:"
           bundle exec rake list
 
-      - name: Extract all lock files from Docker Hub
+      - name: Extract lock files from Docker Hub
+        env:
+          MODE: ${{ github.event.inputs.mode || 'incremental' }}
+          VERSION: ${{ github.event.inputs.version || '' }}
         run: |
-          # Extract all available versions
-          # Already extracted versions will be skipped automatically
-          bundle exec ruby script/extract-locks.rb --all
+          case "$MODE" in
+            incremental)
+              bundle exec ruby script/extract-locks.rb incremental
+              ;;
+            replace)
+              if [ -z "$VERSION" ]; then
+                echo "Error: version input required for replace mode"
+                exit 1
+              fi
+              bundle exec ruby script/extract-locks.rb replace "$VERSION"
+              ;;
+            revamp)
+              bundle exec ruby script/extract-locks.rb revamp
+              ;;
+          esac
 
       - name: Generate index.yaml
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,10 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
-gem "rake"
+gem "paint"
+gem "thor"
+
+group :development do
+  gem "rake"
+end

--- a/README.adoc
+++ b/README.adoc
@@ -157,15 +157,41 @@ To update or extract lock files from Docker Hub:
 # Install dependencies
 bundle install
 
-# Extract all available versions
-rake extract:all
+# Extract only missing versions (incremental mode)
+bundle exec ruby script/extract-locks.rb incremental
+# Or using rake:
+bundle exec rake extract:incremental
 
-# Extract a specific version
-rake extract[1.14.4]
+# Replace a single version (replace mode)
+bundle exec ruby script/extract-locks.rb replace 1.14.4
+# Or using rake:
+bundle exec rake extract:replace[1.14.4]
+
+# Re-extract all versions (revamp mode)
+bundle exec ruby script/extract-locks.rb revamp
+# Or using rake:
+bundle exec rake extract:revamp
 
 # List available versions on Docker Hub
-rake list:versions
+bundle exec ruby script/extract-locks.rb list
+# Or using rake:
+bundle exec rake list:versions
+
+# Test extraction with 3 containers (for testing/index verification)
+bundle exec ruby script/extract-locks.rb test
+# Or using rake:
+bundle exec rake test:extract
 ----
+
+=== Extraction modes
+
+The extraction script supports three modes:
+
+incremental:: Extract only versions that are not present locally. This is the default mode and is used for daily scheduled runs.
+
+replace:: Re-extract a single version, replacing any existing files. Use this to fix corrupted or outdated extractions.
+
+revamp:: Re-extract all versions, replacing all existing files. Use this when the data model changes or you need to refresh all versions.
 
 The extraction script will:
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,18 +4,39 @@ require "rake/clean"
 require "yaml"
 
 namespace :extract do
+  desc "Extract missing versions (incremental)"
+  task :incremental do
+    require_relative "lib/metanorma_gemfile_locks"
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :incremental)
+    extractor.extract_incremental
+  end
+
+  desc "Replace a single version (e.g., rake extract:replace[1.14.4])"
+  task :replace, [:version] do |_t, args|
+    require_relative "lib/metanorma_gemfile_locks"
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :replace)
+    extractor.extract_replace(args[:version])
+  end
+
+  desc "Re-extract all versions (revamp)"
+  task :revamp do
+    require_relative "lib/metanorma_gemfile_locks"
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :revamp)
+    extractor.extract_revamp
+  end
+
   desc "Extract Gemfile/Gemfile.lock for a specific version (e.g., rake extract[1.14.4])"
   task :version, [:version] do |_t, args|
     require_relative "lib/metanorma_gemfile_locks"
-    extractor = MetanormaGemfileLocks::Extractor.new
-    extractor.extract_version(args[:version])
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :replace)
+    extractor.extract_replace(args[:version])
   end
 
   desc "Extract all available versions from Docker Hub"
   task :all do
     require_relative "lib/metanorma_gemfile_locks"
-    extractor = MetanormaGemfileLocks::Extractor.new
-    extractor.extract_all
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :revamp)
+    extractor.extract_revamp
   end
 end
 
@@ -79,6 +100,59 @@ namespace :docker do
     end
 
     puts "Docker cleanup complete. Kept: #{images.last}"
+  end
+end
+
+namespace :test do
+  desc "Test extraction with 3 containers to tmp/test_output"
+  task :extract do
+    require_relative "lib/metanorma_gemfile_locks"
+    require "fileutils"
+
+    versions_dir = File.join(Dir.pwd, "tmp", "test_output", "v")
+    FileUtils.mkdir_p(versions_dir)
+
+    extractor = MetanormaGemfileLocks::Extractor.new(
+      mode: :revamp,
+      versions_dir: versions_dir
+    )
+
+    extractor.extract_test(limit: 3)
+
+    # Generate and verify index
+    index_path = extractor.index_path
+    index = MetanormaGemfileLocks::Index.new(index_path)
+
+    remote_tags = extractor.fetch_docker_hub_versions
+    local_version_objs = extractor.local_versions
+
+    tag_info_by_version = remote_tags.each_with_object({}) { |ti, h| h[ti.name] = ti }
+
+    local_version_objs.each do |version|
+      tag_info = tag_info_by_version[version.number]
+      published_at = tag_info&.published_at || File.stat(version.directory_path).mtime.iso8601
+      parsed_at = Time.now.utc.iso8601
+
+      version.instance_variable_set(:@published_at, published_at)
+      version.instance_variable_set(:@parsed_at, parsed_at)
+      index.add_version(version)
+    end
+
+    missing = remote_tags.map(&:name) - local_version_objs.map(&:number)
+    index.save(remote_tags.size, missing)
+
+    puts "Test complete! Extracted #{local_version_objs.size} versions"
+    puts "Index generated at: #{index_path}"
+
+    # Verify index.yaml structure
+    index_data = YAML.load_file(index_path)
+    first_version = index_data["versions"].first
+
+    if first_version && first_version["published_at"] && first_version["parsed_at"]
+      puts "Index structure verified: published_at and parsed_at present"
+    else
+      raise "Index structure invalid!"
+    end
   end
 end
 

--- a/lib/metanorma_gemfile_locks/logger.rb
+++ b/lib/metanorma_gemfile_locks/logger.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "paint"
+
+module MetanormaGemfileLocks
+  class Logger
+    # Emojis for different log levels
+    EMOJIS = {
+      info: "ℹ️",
+      success: "✅",
+      warning: "⚠️",
+      error: "❌",
+      pulling: "📥",
+      extracting: "📦",
+      skipping: "⏭️",
+      cleaning: "🧹"
+    }.freeze
+
+    class << self
+      def info(message)
+        puts Paint["#{EMOJIS[:info]} #{message}", :cyan]
+      end
+
+      def success(message)
+        puts Paint["#{EMOJIS[:success]} #{message}", :green]
+      end
+
+      def warning(message)
+        warn Paint["#{EMOJIS[:warning]} WARNING: #{message}", :yellow]
+      end
+
+      def error(message)
+        warn Paint["#{EMOJIS[:error]} ERROR: #{message}", :red, :bold]
+      end
+
+      def pulling(version)
+        puts Paint["#{EMOJIS[:pulling]} Pulling #{MetanormaGemfileLocks::DOCKER_IMAGE}:#{version}...", :blue]
+      end
+
+      def extracted(version, from:)
+        puts Paint["  #{EMOJIS[:extracting]} Extracted to v#{version}/ (from #{from})", :green]
+      end
+
+      def skipping(version)
+        puts Paint["  #{EMOJIS[:skipping]} Skipping v#{version}/ (already exists)", :yellow]
+      end
+
+      def header(message)
+        puts "\n" + Paint["=== #{message} ===", :bold, :white] + "\n"
+      end
+
+      def section(message)
+        puts Paint["▸ #{message}", :cyan]
+      end
+
+      def sub(message)
+        puts Paint["  • #{message}", :gray]
+      end
+    end
+  end
+end

--- a/script/extract-locks.rb
+++ b/script/extract-locks.rb
@@ -5,41 +5,94 @@
 # CLI to extract Gemfile and Gemfile.lock from metanorma/metanorma Docker images
 
 require_relative "../lib/metanorma_gemfile_locks"
-require "optparse"
+require "thor"
 
-options = {}
-OptionParser.new do |opts|
-  opts.banner = "Usage: extract-locks.rb [options]"
+class MetanormaGemfileLocksCLI < Thor
+  package_name "metanorma-gemfile-locks"
 
-  opts.on("-vVERSION", "--version=VERSION", "Extract specific version") do |v|
-    options[:version] = v
+  desc "incremental", "Extract only missing versions (default)"
+  def incremental
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :incremental)
+    extractor.extract_incremental
   end
 
-  opts.on("-a", "--all", "Extract all available versions") do
-    options[:all] = true
+  desc "replace VERSION", "Replace a single version"
+  def replace(version)
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :replace)
+    extractor.extract_replace(version)
   end
 
-  opts.on("-l", "--list", "List available versions") do
-    options[:list] = true
+  desc "revamp", "Re-extract all versions"
+  def revamp
+    extractor = MetanormaGemfileLocks::Extractor.new(mode: :revamp)
+    extractor.extract_revamp
   end
 
-  opts.on("-h", "--help", "Prints this help") do
-    puts opts
-    exit
+  desc "list", "List available versions from Docker Hub"
+  def list
+    extractor = MetanormaGemfileLocks::Extractor.new
+    tags = extractor.fetch_docker_hub_versions
+    MetanormaGemfileLocks::Logger.header "Available versions"
+    tags.each { |t| MetanormaGemfileLocks::Logger.sub "#{t.name} (#{t.published_at})" }
   end
-end.parse!
 
-extractor = MetanormaGemfileLocks::Extractor.new
+  desc "test [OUTPUT_DIR]", "Extract 3 versions to a test directory (default: tmp/test_output)"
+  def test(output_dir = "tmp/test_output")
+    require "fileutils"
 
-if options[:list]
-  versions = extractor.fetch_docker_hub_versions
-  puts "Available versions:"
-  versions.each { |v| puts "  #{v}" }
-elsif options[:version]
-  extractor.extract_version(options[:version])
-elsif options[:all]
-  extractor.extract_all
-else
-  puts "Use --help for usage information"
-  exit 1
+    # Create temp output directory
+    versions_dir = File.join(Dir.pwd, output_dir, "v")
+    FileUtils.mkdir_p(versions_dir)
+
+    # Create extractor with custom versions_dir
+    extractor = MetanormaGemfileLocks::Extractor.new(
+      mode: :revamp,
+      versions_dir: versions_dir
+    )
+
+    # Extract 3 versions
+    extractor.extract_test(limit: 3)
+
+    # Generate index
+    index_path = extractor.index_path
+    index = MetanormaGemfileLocks::Index.new(index_path)
+
+    remote_tags = extractor.fetch_docker_hub_versions
+    local_version_objs = extractor.local_versions
+
+    # Build tag info cache
+    tag_info_by_version = remote_tags.each_with_object({}) { |ti, h| h[ti.name] = ti }
+
+    local_version_objs.each do |version|
+      tag_info = tag_info_by_version[version.number]
+      published_at = tag_info&.published_at || File.stat(version.directory_path).mtime.iso8601
+      parsed_at = Time.now.utc.iso8601
+
+      version.instance_variable_set(:@published_at, published_at)
+      version.instance_variable_set(:@parsed_at, parsed_at)
+      index.add_version(version)
+    end
+
+    missing = remote_tags.map(&:name) - local_version_objs.map(&:number)
+    index.save(remote_tags.size, missing)
+
+    MetanormaGemfileLocks::Logger.success "Test complete! Extracted #{local_version_objs.size} versions"
+    MetanormaGemfileLocks::Logger.info "Index generated at: #{index_path}"
+
+    # Verify index.yaml structure
+    require "yaml"
+    index_data = YAML.load_file(index_path)
+    first_version = index_data["versions"].first
+
+    if first_version && first_version["published_at"] && first_version["parsed_at"]
+      MetanormaGemfileLocks::Logger.success "Index structure verified: published_at and parsed_at present"
+    else
+      MetanormaGemfileLocks::Logger.error "Index structure invalid!"
+      exit 1
+    end
+  end
+
+  default_task :incremental
 end
+
+MetanormaGemfileLocksCLI.start(ARGV)


### PR DESCRIPTION
## Summary

Add three extraction modes (incremental, replace, revamp) and update
index.yaml to use `published_at` (Docker Hub publish date) and `parsed_at`
(extraction timestamp) instead of single `updated_at`.

## Changes

- Add `Logger` class with Paint for colored output
- Add `TagInfo` class for Docker Hub tag metadata
- Update `Version` class with `published_at` and `parsed_at` fields
- Update `Index` class with migration support for old format
- Update `Extractor` class with incremental, replace, and revamp modes
- Replace OptionParser with Thor CLI
- Update GitHub workflow with mode and version inputs
- Update Rakefile with new extraction tasks
- Update Gemfile with paint and thor dependencies
- Update README.adoc with new CLI commands

## New index.yaml Structure

### Before:
```yaml
versions:
  - version: "1.13.5"
    updated_at: "2026-02-09T12:06:25+00:00"
```

### After:
```yaml
versions:
  - version: "1.13.5"
    published_at: "2023-01-15T10:30:00Z"  # Docker Hub publish date
    parsed_at: "2026-02-09T12:06:25+00:00"  # Extraction timestamp
```

## Extraction Modes

| Mode | Description | Use Case |
|------|-------------|----------|
| `incremental` | Extract only missing versions | Default/daily scheduled runs |
| `replace` | Re-extract a single version | Fix corrupted extraction |
| `revamp` | Re-extract all versions | Data model changes |

## Test plan

### CI Tests (automated on every PR)
- [x] Test CLI help command
- [x] Test CLI list command (fetches from Docker Hub API, no Docker required)
- [x] Test extraction with 3 containers to `tmp/test_output/`
- [x] Verify index.yaml has `published_at` and `parsed_at` fields

### Manual tests (run locally, requires Docker)
- [ ] `bundle exec ruby script/extract-locks.rb incremental`
- [ ] `bundle exec ruby script/extract-locks.rb replace 1.13.5`
- [ ] `bundle exec ruby script/extract-locks.rb revamp` (slow - extracts all 119 versions)

### Post-merge tests (run on GitHub Actions)
- [ ] Trigger revamp mode: `gh workflow run update-locks.yml -f mode=revamp`