### PR TITLE
fix: correct stale gemfile_exists data for v1.15.0/v1.15.1

### DIFF
--- a/data/gemfile/v1.15.0/Gemfile
+++ b/data/gemfile/v1.15.0/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "metanorma-cli", "= 1.15.0"

--- a/data/gemfile/v1.15.0/Gemfile.lock.archived
+++ b/data/gemfile/v1.15.0/Gemfile.lock.archived
@@ -1,0 +1,957 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    algolia (2.3.4)
+      faraday (>= 0.15, < 3)
+      faraday-net_http_persistent (>= 0.15, < 3)
+      multi_json (~> 1.0)
+      net-http-persistent
+    arr-pm (0.0.12)
+    asciidoctor (2.0.26)
+    base64 (0.3.0)
+    bcp47_spec (0.2.1)
+    benchmark-ips (2.14.0)
+    bibtex-ruby (6.2.0)
+      latex-decode (~> 0.0)
+      logger (~> 1.7)
+      racc (~> 1.7)
+    bigdecimal (4.0.1)
+    bindata (2.5.1)
+    brotli (0.7.0)
+    camertron-eprun (1.1.1)
+    cldr-plurals-runtime-rb (1.1.0)
+    cliver (0.3.2)
+    cnccs (0.1.6)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.4.1)
+    coradoc (1.1.7)
+      base64
+      marcel (~> 1.0.0)
+      nokogiri (~> 1.13)
+      oscal (~> 0.1.1)
+      parslet
+      plurimath
+      thor (>= 1.3.0)
+      unitsml
+      word-to-markdown
+    crass (1.0.6)
+    creek (2.6.3)
+      nokogiri (>= 1.10.0)
+      rubyzip (>= 1.0.0)
+    css_parser (1.21.1)
+      addressable
+    csv (3.3.5)
+    date (3.5.1)
+    descriptive_statistics (2.5.1)
+    domain_name (0.6.20240107)
+    down (5.4.2)
+      addressable (~> 2.8)
+    drb (2.2.3)
+    ebnf (2.6.0)
+      base64 (~> 0.2)
+      htmlentities (~> 4.3)
+      rdf (~> 3.3)
+      scanf (~> 1.0)
+      sxp (~> 2.0)
+      unicode-types (~> 1.8)
+    emf2svg (1.4.3)
+      ffi (~> 1.0)
+      mini_portile2 (~> 2.6)
+    emf2svg (1.4.3-aarch64-linux)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-arm64-darwin)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-x86_64-darwin)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-x86_64-linux)
+      ffi (~> 1.0)
+    excavate (0.3.9)
+      arr-pm (~> 0.0)
+      ffi-compiler2 (>= 2.2.2)
+      ffi-libarchive-binary (~> 0.4, >= 0.4.2)
+      libmspack (~> 0.1)
+      ruby-ole (~> 1.0)
+      rubyzip (~> 2.3)
+      seven-zip (~> 1.4)
+      thor (~> 1.0)
+    expressir (2.1.31)
+      base64
+      benchmark-ips
+      csv
+      liquid
+      lutaml-model
+      moxml
+      paint
+      parslet (~> 2.0)
+      ruby-progressbar (~> 1.11)
+      rubyzip (~> 2.3)
+      table_tennis
+      thor (~> 1.0)
+    faraday (2.7.12)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    ffi-compiler2 (2.3.0)
+      ffi (>= 1.0.0)
+      rake
+    ffi-libarchive (1.1.14)
+      ffi (~> 1.0)
+    ffi-libarchive-binary (0.5.3)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      mini_portile2 (~> 2.7)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux-gnu)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux-musl)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-arm64-darwin)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-darwin)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-linux-gnu)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-linux-musl)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    fiber-storage (1.0.1)
+    fontisan (0.2.14)
+      base64
+      bindata (~> 2.5)
+      brotli (~> 0.5)
+      lutaml-model (~> 0.7)
+      nokogiri (~> 1.16)
+      thor (~> 1.3)
+    fontist (2.1.2)
+      down (~> 5.0)
+      excavate (~> 0.3, >= 0.3.8)
+      fontisan (~> 0.2, >= 0.2.11)
+      fuzzy_match (~> 2.1)
+      git (> 1.0)
+      json (~> 2.0)
+      lutaml-model (~> 0.7)
+      lutaml-xsd (~> 1.0)
+      marcel (~> 1.0)
+      nokogiri (~> 1.0)
+      octokit (~> 4.0)
+      paint (~> 2.3)
+      parallel (~> 1.24)
+      plist (~> 3.0)
+      socksify (~> 1.7)
+      thor (~> 1.4)
+      unibuf (~> 0.1)
+    fuzzy_match (2.1.0)
+    gb-agencies (0.0.7)
+    git (2.3.3)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
+    glossarist (2.3.11)
+      lutaml-model (~> 0.7)
+      relaton (~> 1.19)
+      thor
+    graphql (2.5.19)
+      base64
+      fiber-storage
+      logger
+    graphql-client (0.26.0)
+      activesupport (>= 3.0)
+      graphql (>= 1.13.0)
+    hashie (4.1.0)
+    hollaback (0.1.1)
+    html2doc (1.10.3)
+      base64
+      htmlentities (~> 4.3.4)
+      lutaml-model (~> 0.7.0)
+      marcel
+      metanorma-utils (>= 1.9.0)
+      nokogiri (~> 1.18.3)
+      plane1converter (~> 0.0.1)
+      plurimath (~> 0.9.0)
+      thread_safe
+      uuidtools
+      vectory (~> 0.8)
+    htmlentities (4.3.4)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    ieee-idams (0.2.14)
+      lutaml-model (~> 0.7)
+      nokogiri
+      thor
+    iev (0.3.9)
+      creek (~> 2.6)
+      glossarist (>= 2.3.0)
+      mechanize (~> 2.10)
+      nokogiri (~> 1.17)
+      plurimath
+      relaton (~> 1.18)
+      sequel (~> 5.40)
+      sqlite3 (~> 1.7.0)
+      thor (~> 1.0)
+      unitsml
+    image_size (3.4.0)
+    iso-639 (0.3.8)
+      csv
+    iso639 (1.3.3)
+    isodoc (3.4.4)
+      base64
+      bigdecimal
+      html2doc (~> 1.10.0)
+      mn-requirements (~> 0.5.0)
+      mn2pdf (>= 2.13)
+      relaton-render (~> 1.0.0)
+      roman-numerals
+      rouge (~> 4.0)
+      thread_safe
+      twitter_cldr (>= 6.6.0)
+      uuidtools
+    isodoc-i18n (1.4.3)
+      base64
+      htmlentities (~> 4.3.4)
+      liquid (~> 5)
+      metanorma-utils (>= 1.7.0)
+      twitter_cldr
+    isoics (0.1.13)
+    japanese_calendar (0.4.2)
+    json (2.18.1)
+    latex-decode (0.4.2)
+    libmspack (0.11.0)
+      ffi
+      ffi-compiler2 (>= 2.0.0)
+    lightly (0.4.0)
+    link_header (0.0.8)
+    liquid (5.11.0)
+      bigdecimal
+      strscan (>= 3.1.1)
+    loc_mods (0.2.7)
+      lutaml-model (~> 0.5)
+      nokogiri
+      thor
+    logger (1.7.0)
+    lutaml (0.9.43)
+      expressir (~> 2.1.0)
+      hashie (~> 4.1.0)
+      htmlentities
+      liquid
+      lutaml-model
+      lutaml-path
+      lutaml-xsd
+      nokogiri (~> 1.10)
+      parslet (~> 2.0.0)
+      ruby-graphviz (~> 1.2)
+      thor (~> 1.0)
+      xmi (~> 0.3.20)
+    lutaml-hal (0.1.10)
+      faraday (~> 2.0)
+      faraday-follow_redirects (~> 0.3)
+      lutaml-model
+      rainbow (~> 3.0)
+    lutaml-model (0.7.7)
+      moxml (>= 0.1.2)
+      thor
+    lutaml-path (0.1.0)
+      parslet
+    lutaml-xsd (1.0.4)
+      lutaml-model (~> 0.7)
+      zeitwerk
+    marcel (1.0.4)
+    matrix (0.4.3)
+    mechanize (2.14.0)
+      addressable (~> 2.8)
+      base64
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.3)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
+    memo_wise (1.13.0)
+    metanorma (2.3.1)
+      asciidoctor
+      concurrent-ruby
+      fontist (>= 2.0.0)
+      htmlentities
+      isodoc (>= 3.0.0)
+      marcel
+      metanorma-taste (~> 0.1.0)
+      mn2pdf (~> 2)
+      nokogiri
+      relaton-cli
+    metanorma-bipm (2.8.0)
+      metanorma-generic (~> 3.2.3)
+      metanorma-iso (~> 3.3.0)
+    metanorma-cc (2.8.0)
+      metanorma-generic (~> 3.2.3)
+    metanorma-cli (1.15.0)
+      git (~> 2.0)
+      liquid (~> 5)
+      lutaml-model
+      metanorma (~> 2.3.0)
+      metanorma-bipm (~> 2.8.0)
+      metanorma-cc (~> 2.8.0)
+      metanorma-generic (~> 3.2.3)
+      metanorma-iec (~> 2.8.0)
+      metanorma-ieee (~> 1.6.0)
+      metanorma-ietf (~> 3.7.0)
+      metanorma-iho (~> 1.3.0)
+      metanorma-iso (~> 3.3.0)
+      metanorma-itu (~> 2.8.0)
+      metanorma-jis (~> 1.0.0)
+      metanorma-ogc (~> 2.9.0)
+      metanorma-plateau (~> 1.2.0)
+      metanorma-ribose (~> 2.8.0)
+      metanorma-standoc (~> 3.3.0)
+      mnconvert
+      relaton-cli (>= 0.8.2)
+      socksify
+      suma (~> 0.2.0)
+    metanorma-generic (3.2.3)
+      metanorma-standoc (~> 3.3.0)
+    metanorma-iec (2.8.0)
+      metanorma-iso (~> 3.3.0)
+      pubid
+    metanorma-ieee (1.6.3)
+      metanorma-standoc (~> 3.3.0)
+      mnconvert (~> 1.20)
+      pubid
+    metanorma-ietf (3.7.0)
+      metanorma-ietf-data
+      metanorma-standoc (~> 3.3.0)
+      relaton-render
+    metanorma-ietf-data (0.2.0)
+    metanorma-iho (1.3.0)
+      metanorma-generic (~> 3.2.3)
+    metanorma-iso (3.3.0)
+      metanorma-standoc (~> 3.3.0)
+      mnconvert (~> 1.14)
+      pubid
+      tokenizer (~> 0.3.0)
+    metanorma-itu (2.8.3)
+      metanorma-standoc (~> 3.3.0)
+      pubid
+      twitter_cldr (>= 3.0.0)
+      tzinfo-data
+    metanorma-jis (1.0.3)
+      japanese_calendar (~> 0)
+      metanorma-iso (~> 3.3.0)
+      pubid
+    metanorma-ogc (2.9.0)
+      iso-639
+      metanorma-standoc (~> 3.3.0)
+    metanorma-plateau (1.2.4)
+      metanorma-jis (~> 1.0.3)
+      pubid
+    metanorma-plugin-glossarist (0.2.11)
+      asciidoctor
+      glossarist (~> 2.3.7)
+      liquid
+      metanorma-utils (~> 2.0)
+    metanorma-plugin-lutaml (0.7.38)
+      asciidoctor
+      coradoc (~> 1.1)
+      expressir (~> 2.1)
+      isodoc
+      liquid
+      lutaml (~> 0.9)
+      ogc-gml (~> 1.0.0)
+      relaton-cli
+    metanorma-plugin-plantuml (1.0.9)
+      asciidoctor
+      isodoc
+    metanorma-ribose (2.8.0)
+      metanorma-generic (~> 3.2.0)
+    metanorma-standoc (3.3.0)
+      addressable (~> 2.8.0)
+      asciidoctor (~> 2.0.0)
+      concurrent-ruby
+      crass (~> 1.0.0)
+      iev (~> 0.3.5)
+      isodoc (~> 3.4.0)
+      metanorma (>= 1.6.0)
+      metanorma-plugin-glossarist (~> 0.2.3)
+      metanorma-plugin-lutaml (~> 0.7.31)
+      metanorma-plugin-plantuml (~> 1.0.0)
+      metanorma-utils (~> 2.0.1)
+      png_conform (~> 0.1.0)
+      relaton-cli (~> 1.20.0)
+      relaton-iev (~> 1.2.0)
+      ruby-jing
+      svg_conform (~> 0.1.0)
+    metanorma-taste (0.1.11)
+      lutaml-model (~> 0.7)
+    metanorma-utils (2.0.3)
+      asciidoctor (>= 2)
+      concurrent-ruby
+      csv
+      htmlentities (~> 4.3.4)
+      nokogiri (>= 1.11)
+      sterile (~> 1.0.14)
+      uuidtools
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0203)
+    mini_portile2 (2.8.9)
+    minitest (6.0.1)
+      prism (~> 1.5)
+    mml (2.0.3)
+      lutaml-model
+      moxml
+    mn-requirements (0.5.8)
+      isodoc-i18n (>= 1.2.0)
+      metanorma-utils (>= 2.0.0)
+      relaton-render (>= 1.0.0)
+    mn2pdf (2.45)
+    mnconvert (1.79.0)
+    moxml (0.1.10)
+    multi_json (1.15.0)
+    net-ftp (0.1.4)
+      net-protocol
+      time
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
+    net-protocol (0.2.2)
+      timeout
+    nkf (0.2.0)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
+    nokogiri-styles (0.1.2)
+      nokogiri
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    ogc-gml (1.0.4)
+      lutaml-model (~> 0.7)
+      nokogiri
+    openssl (3.3.2)
+    optout (0.0.2)
+    oscal (0.1.1)
+      yaml
+    ox (2.14.23)
+      bigdecimal (>= 3.0)
+    paint (2.3.0)
+    parallel (1.27.0)
+    parslet (2.0.0)
+    plane1converter (0.0.1)
+    plist (3.7.2)
+    plurimath (0.9.11)
+      bigdecimal
+      lutaml-model
+      mml
+      ox
+      parslet
+      thor
+      unitsml
+    png_conform (0.1.3)
+      bindata (~> 2.5)
+      lutaml-model (~> 0.7)
+      paint (~> 2.3)
+      thor (~> 1.4)
+    premailer (1.27.0)
+      addressable
+      css_parser (>= 1.19.0)
+      htmlentities (>= 4.0.0)
+    prism (1.9.0)
+    process_executer (1.3.0)
+    pubid (1.15.6)
+      pubid-bsi (= 1.15.6)
+      pubid-ccsds (= 1.15.6)
+      pubid-cen (= 1.15.6)
+      pubid-core (= 1.15.6)
+      pubid-etsi (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-ieee (= 1.15.6)
+      pubid-iso (= 1.15.6)
+      pubid-itu (= 1.15.6)
+      pubid-jis (= 1.15.6)
+      pubid-nist (= 1.15.6)
+      pubid-plateau (= 1.15.6)
+    pubid-bsi (1.15.6)
+      parslet
+      pubid-cen (= 1.15.6)
+      pubid-core (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-iso (= 1.15.6)
+    pubid-ccsds (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-cen (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-iso (= 1.15.6)
+    pubid-core (1.15.6)
+      parslet
+    pubid-etsi (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-iec (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-ieee (1.15.6)
+      parslet (~> 2.0.0)
+      pubid-iso (= 1.15.6)
+    pubid-iso (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-itu (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-jis (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-nist (1.15.6)
+      lightly
+      nokogiri
+      parslet
+      pubid-core (= 1.15.6)
+      rubyzip
+      thor
+    pubid-plateau (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    public_suffix (7.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rchardet (1.10.0)
+    rdf (3.3.1)
+      bcp47_spec (~> 0.2)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-turtle (3.3.0)
+      ebnf (~> 2.4)
+      rdf (~> 3.3)
+    relaton (1.20.2)
+      relaton-3gpp (~> 1.20.0)
+      relaton-bipm (~> 1.20.0)
+      relaton-bsi (~> 1.20.0)
+      relaton-calconnect (~> 1.20.0)
+      relaton-ccsds (~> 1.20.2)
+      relaton-cen (~> 1.20.0)
+      relaton-cie (~> 1.20.0)
+      relaton-doi (~> 1.20.0)
+      relaton-ecma (~> 1.20.0)
+      relaton-etsi (~> 1.20.0)
+      relaton-gb (~> 1.20.0)
+      relaton-iana (~> 1.20.0)
+      relaton-iec (~> 1.20.3)
+      relaton-ieee (~> 1.20.0)
+      relaton-ietf (~> 1.20.0)
+      relaton-iho (~> 1.20.0)
+      relaton-isbn (~> 1.20.0)
+      relaton-iso (~> 1.20.0)
+      relaton-itu (~> 1.20.0)
+      relaton-jis (~> 1.20.0)
+      relaton-nist (~> 1.20.0)
+      relaton-oasis (~> 1.20.0)
+      relaton-ogc (~> 1.20.0)
+      relaton-omg (~> 1.20.0)
+      relaton-plateau (~> 1.20.0)
+      relaton-un (~> 1.20.0)
+      relaton-w3c (~> 1.20.0)
+      relaton-xsf (~> 1.20.0)
+    relaton-3gpp (1.20.0)
+      csv
+      net-ftp (~> 0.1.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-bib (1.20.7)
+      addressable
+      bibtex-ruby
+      htmlentities
+      iso639
+      nokogiri (~> 1.18.3)
+      relaton-logger (~> 0.2.0)
+    relaton-bipm (1.20.4)
+      faraday (~> 2.7.0)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.2)
+      rubyzip (~> 2.3.0)
+    relaton-bsi (1.20.1)
+      algolia (~> 2.3.0)
+      faraday-net_http_persistent (~> 2.0)
+      graphql (~> 2.3)
+      graphql-client (~> 0.23)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-calconnect (1.20.1)
+      faraday (~> 2.7.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-ccsds (1.20.3)
+      mechanize (~> 2.10)
+      pubid-ccsds (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.17)
+    relaton-cen (1.20.2)
+      mechanize (~> 2.10)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-cie (1.20.1)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-cli (1.20.6)
+      liquid (~> 5)
+      relaton (~> 1.20.2)
+      thor
+      thor-hollaback
+    relaton-core (0.0.7)
+      relaton-logger (~> 0.2.0)
+    relaton-doi (1.20.1)
+      faraday (~> 2.7)
+      relaton-bib (~> 1.20.0)
+      relaton-bipm (~> 1.20.0)
+      relaton-ieee (~> 1.20.0)
+      relaton-ietf (~> 1.20.0)
+      relaton-nist (~> 1.20.0)
+    relaton-ecma (1.20.1)
+      mechanize (~> 2.10)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.4)
+    relaton-etsi (1.20.2)
+      csv (~> 3.0)
+      mechanize (~> 2.8)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.7)
+    relaton-gb (1.20.2)
+      cnccs (~> 0.1.1)
+      connection_pool (~> 2.4.0)
+      csv (~> 3.0)
+      gb-agencies (~> 0.0.1)
+      mechanize (~> 2.10)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-iana (1.20.0)
+      faraday (~> 2.7.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-iec (1.20.3)
+      addressable
+      base64
+      mechanize (~> 2.8)
+      pubid-iec (~> 1.15.4)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+      rubyzip
+    relaton-ieee (1.20.2)
+      faraday (~> 2.7.0)
+      ieee-idams (~> 0.2.14)
+      mini_portile2 (~> 2.8.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+      rubyzip (~> 2.3.0)
+    relaton-ietf (1.20.0)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.3)
+    relaton-iev (1.2.1)
+      htmlentities (~> 4.3.4)
+      nokogiri (>= 1.13.0)
+      relaton (>= 1.15)
+      uuidtools
+    relaton-iho (1.20.4)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-index (0.2.20)
+      openssl (~> 3.3.2)
+      pubid-core (~> 1.15.6)
+      relaton-logger (~> 0.2.0)
+      rubyzip (~> 2.3.0)
+    relaton-isbn (1.20.1)
+      relaton-bib (~> 1.20.0)
+    relaton-iso (1.20.1)
+      openssl (>= 3.3.2)
+      pubid-iso (~> 1.15.0)
+      relaton-index (~> 0.2.17)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-iso-bib (1.20.0)
+      isoics (~> 0.1.6)
+      relaton-bib (~> 1.20.0)
+    relaton-itu (1.20.4)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-core (~> 0.0.6)
+      relaton-index (~> 0.2.0)
+    relaton-jis (1.20.0)
+      mechanize (~> 2.10)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-logger (0.2.3)
+      logger (~> 1.6)
+    relaton-nist (1.20.3)
+      base64
+      loc_mods (~> 0.2.0)
+      pubid (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+      rubyzip
+    relaton-oasis (1.20.0)
+      mechanize (~> 2.10)
+      multi_json (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-ogc (1.20.1)
+      faraday (~> 2.7.0)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-omg (1.20.1)
+      base64
+      mechanize (~> 2.8)
+      relaton-bib (~> 1.20.0)
+    relaton-plateau (1.20.0)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.12)
+      relaton-logger (~> 0.2.0)
+    relaton-render (1.0.4)
+      base64
+      bigdecimal
+      isodoc-i18n (~> 1.4.0)
+      liquid (~> 5)
+      metanorma-utils (~> 2)
+      nokogiri
+      relaton-bib (>= 1.20.0)
+      twitter_cldr
+      tzinfo-data
+    relaton-un (1.20.1)
+      addressable (~> 2.8.0)
+      faraday (~> 2.7.0)
+      http-cookie (~> 1.0.5)
+      relaton-bib (~> 1.20.0)
+    relaton-w3c (1.20.1)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.8)
+      w3c_api (~> 0.1.3)
+    relaton-xsf (1.20.0)
+      mechanize (~> 2.10)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    reverse_markdown (2.1.1)
+      nokogiri
+    rexml (3.4.4)
+    roman-numerals (0.3.0)
+    rouge (4.7.0)
+    ruby-graphviz (1.2.5)
+      rexml
+    ruby-jing (0.0.3)
+      optout (>= 0.0.2)
+    ruby-ole (1.2.13.1)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyntlm (0.6.5)
+      base64
+    rubyzip (2.3.2)
+    sawyer (0.9.3)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    scanf (1.0.0)
+    securerandom (0.4.1)
+    sequel (5.101.0)
+      bigdecimal
+    seven-zip (1.4.2)
+    socksify (1.8.1)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    sterile (1.0.26)
+      nokogiri (>= 1.11.7)
+    strscan (3.1.7)
+    suma (0.2.4)
+      expressir (~> 2.1, >= 2.1.29)
+      glossarist (~> 2.3.7)
+      lutaml-model (~> 0.7)
+      metanorma (~> 2.3)
+      plurimath
+      ruby-progressbar
+      rubyzip (~> 2.3)
+      table_tennis
+      thor (>= 0.20)
+    svg_conform (0.1.11)
+      lutaml-model (~> 0.7)
+      moxml (~> 0.1, >= 0.1.10)
+      table_tennis
+      thor
+    sxp (2.0.0)
+      matrix (~> 0.4)
+      rdf (~> 3.3)
+    sys-proctable (1.3.0)
+      ffi (~> 1.1)
+    table_tennis (0.0.7)
+      csv (~> 3.3)
+      ffi (~> 1.17)
+      memo_wise (~> 1.11)
+      paint (~> 2.3)
+      unicode-display_width (~> 3.1)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    thor (1.5.0)
+    thor-hollaback (0.2.1)
+      hollaback (~> 0.1)
+      thor (>= 0.19.1)
+    thread_safe (0.3.6)
+    time (0.4.2)
+      date
+    timeout (0.6.0)
+    tokenizer (0.3.0)
+    twitter_cldr (6.14.0)
+      base64
+      camertron-eprun
+      cldr-plurals-runtime-rb (~> 1.1)
+      tzinfo
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.3)
+      tzinfo (>= 1.0.0)
+    unibuf (0.1.2)
+      bindata (~> 2.5)
+      lutaml-model (~> 0.7)
+      parslet (~> 2.0)
+      thor (~> 1.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    unicode-types (1.11.0)
+    unitsdb (2.1.1)
+      lutaml-model (~> 0.7)
+      rdf (~> 3.1)
+      rdf-turtle (~> 3.1)
+      rubyzip (~> 2.3)
+      terminal-table
+      thor (~> 1.0)
+    unitsml (0.5.1)
+      htmlentities
+      lutaml-model (~> 0.7.6)
+      mml
+      parslet
+      unitsdb (~> 2.0)
+    uri (1.1.1)
+    uuidtools (3.0.0)
+    vectory (0.8.2)
+      base64
+      emf2svg
+      image_size (>= 3.2.0)
+      marcel (~> 1.0)
+      nokogiri (~> 1.14)
+      thor (~> 1.0)
+    w3c_api (0.1.7)
+      faraday
+      faraday-follow_redirects
+      lutaml-hal (~> 0.1.10)
+      rainbow
+      thor
+    webrick (1.9.2)
+    webrobots (0.1.2)
+    word-to-markdown (1.1.9)
+      cliver (~> 0.3)
+      descriptive_statistics (~> 2.5)
+      nokogiri-styles (~> 0.1)
+      premailer (~> 1.8)
+      reverse_markdown (>= 1, < 3)
+      sys-proctable (~> 1.0)
+    xmi (0.3.21)
+      lutaml-model (~> 0.7)
+      nokogiri
+    yaml (0.4.0)
+    zeitwerk (2.7.5)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  metanorma-cli (= 1.15.0)
+
+BUNDLED WITH
+   2.6.9

--- a/data/gemfile/v1.15.1/Gemfile
+++ b/data/gemfile/v1.15.1/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "metanorma-cli", "= 1.15.1"

--- a/data/gemfile/v1.15.1/Gemfile.lock.archived
+++ b/data/gemfile/v1.15.1/Gemfile.lock.archived
@@ -1,0 +1,958 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
+    algolia (2.3.4)
+      faraday (>= 0.15, < 3)
+      faraday-net_http_persistent (>= 0.15, < 3)
+      multi_json (~> 1.0)
+      net-http-persistent
+    arr-pm (0.0.12)
+    asciidoctor (2.0.26)
+    base64 (0.3.0)
+    bcp47_spec (0.2.1)
+    benchmark-ips (2.14.0)
+    bibtex-ruby (6.2.0)
+      latex-decode (~> 0.0)
+      logger (~> 1.7)
+      racc (~> 1.7)
+    bigdecimal (4.0.1)
+    bindata (2.5.1)
+    brotli (0.7.0)
+    camertron-eprun (1.1.1)
+    cldr-plurals-runtime-rb (1.1.0)
+    cliver (0.3.2)
+    cnccs (0.1.6)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.4.1)
+    coradoc (1.1.7)
+      base64
+      marcel (~> 1.0.0)
+      nokogiri (~> 1.13)
+      oscal (~> 0.1.1)
+      parslet
+      plurimath
+      thor (>= 1.3.0)
+      unitsml
+      word-to-markdown
+    crass (1.0.6)
+    creek (2.6.3)
+      nokogiri (>= 1.10.0)
+      rubyzip (>= 1.0.0)
+    css_parser (2.0.0)
+      addressable
+    csv (3.3.5)
+    date (3.5.1)
+    descriptive_statistics (2.5.1)
+    domain_name (0.6.20240107)
+    down (5.4.2)
+      addressable (~> 2.8)
+    drb (2.2.3)
+    ebnf (2.6.0)
+      base64 (~> 0.2)
+      htmlentities (~> 4.3)
+      rdf (~> 3.3)
+      scanf (~> 1.0)
+      sxp (~> 2.0)
+      unicode-types (~> 1.8)
+    emf2svg (1.4.3)
+      ffi (~> 1.0)
+      mini_portile2 (~> 2.6)
+    emf2svg (1.4.3-aarch64-linux)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-arm64-darwin)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-x86_64-darwin)
+      ffi (~> 1.0)
+    emf2svg (1.4.3-x86_64-linux)
+      ffi (~> 1.0)
+    excavate (0.3.9)
+      arr-pm (~> 0.0)
+      ffi-compiler2 (>= 2.2.2)
+      ffi-libarchive-binary (~> 0.4, >= 0.4.2)
+      libmspack (~> 0.1)
+      ruby-ole (~> 1.0)
+      rubyzip (~> 2.3)
+      seven-zip (~> 1.4)
+      thor (~> 1.0)
+    expressir (2.1.31)
+      base64
+      benchmark-ips
+      csv
+      liquid
+      lutaml-model
+      moxml
+      paint
+      parslet (~> 2.0)
+      ruby-progressbar (~> 1.11)
+      rubyzip (~> 2.3)
+      table_tennis
+      thor (~> 1.0)
+    faraday (2.7.12)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.0.2)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    ffi-compiler2 (2.3.0)
+      ffi (>= 1.0.0)
+      rake
+    ffi-libarchive (1.1.14)
+      ffi (~> 1.0)
+    ffi-libarchive-binary (0.5.3)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      mini_portile2 (~> 2.7)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux-gnu)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-aarch64-linux-musl)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-arm64-darwin)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-darwin)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-linux-gnu)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    ffi-libarchive-binary (0.5.3-x86_64-linux-musl)
+      ffi (~> 1.0)
+      ffi-libarchive (~> 1.0)
+      rake (~> 13.0)
+    fiber-storage (1.0.1)
+    fontisan (0.2.14)
+      base64
+      bindata (~> 2.5)
+      brotli (~> 0.5)
+      lutaml-model (~> 0.7)
+      nokogiri (~> 1.16)
+      thor (~> 1.3)
+    fontist (2.1.2)
+      down (~> 5.0)
+      excavate (~> 0.3, >= 0.3.8)
+      fontisan (~> 0.2, >= 0.2.11)
+      fuzzy_match (~> 2.1)
+      git (> 1.0)
+      json (~> 2.0)
+      lutaml-model (~> 0.7)
+      lutaml-xsd (~> 1.0)
+      marcel (~> 1.0)
+      nokogiri (~> 1.0)
+      octokit (~> 4.0)
+      paint (~> 2.3)
+      parallel (~> 1.24)
+      plist (~> 3.0)
+      socksify (~> 1.7)
+      thor (~> 1.4)
+      unibuf (~> 0.1)
+    fuzzy_match (2.1.0)
+    gb-agencies (0.0.7)
+    git (2.3.3)
+      activesupport (>= 5.0)
+      addressable (~> 2.8)
+      process_executer (~> 1.1)
+      rchardet (~> 1.8)
+    glossarist (2.3.11)
+      lutaml-model (~> 0.7)
+      relaton (~> 1.19)
+      thor
+    graphql (2.5.20)
+      base64
+      fiber-storage
+      logger
+    graphql-client (0.26.0)
+      activesupport (>= 3.0)
+      graphql (>= 1.13.0)
+    hashie (4.1.0)
+    hollaback (0.1.1)
+    html2doc (1.10.4)
+      base64
+      htmlentities (~> 4.3.4)
+      lutaml-model (~> 0.7.0)
+      marcel
+      metanorma-utils (>= 1.9.0)
+      nokogiri (~> 1.18.3)
+      plane1converter (~> 0.0.1)
+      plurimath (~> 0.9.0)
+      thread_safe
+      uuidtools
+      vectory (~> 0.8)
+    htmlentities (4.3.4)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    ieee-idams (0.2.14)
+      lutaml-model (~> 0.7)
+      nokogiri
+      thor
+    iev (0.3.9)
+      creek (~> 2.6)
+      glossarist (>= 2.3.0)
+      mechanize (~> 2.10)
+      nokogiri (~> 1.17)
+      plurimath
+      relaton (~> 1.18)
+      sequel (~> 5.40)
+      sqlite3 (~> 1.7.0)
+      thor (~> 1.0)
+      unitsml
+    image_size (3.4.0)
+    iso-639 (0.3.8)
+      csv
+    iso639 (1.3.3)
+    isodoc (3.4.5)
+      base64
+      bigdecimal
+      html2doc (~> 1.10.0)
+      mn-requirements (~> 0.5.0)
+      mn2pdf (>= 2.13)
+      relaton-render (~> 1.0.0)
+      roman-numerals
+      rouge (~> 4.0)
+      thread_safe
+      twitter_cldr (>= 6.6.0)
+      uuidtools
+    isodoc-i18n (1.4.3)
+      base64
+      htmlentities (~> 4.3.4)
+      liquid (~> 5)
+      metanorma-utils (>= 1.7.0)
+      twitter_cldr
+    isoics (0.1.13)
+    japanese_calendar (0.4.2)
+    json (2.18.1)
+    latex-decode (0.4.2)
+    libmspack (0.11.0)
+      ffi
+      ffi-compiler2 (>= 2.0.0)
+    lightly (0.4.0)
+    link_header (0.0.8)
+    liquid (5.11.0)
+      bigdecimal
+      strscan (>= 3.1.1)
+    loc_mods (0.2.7)
+      lutaml-model (~> 0.5)
+      nokogiri
+      thor
+    logger (1.7.0)
+    lutaml (0.9.43)
+      expressir (~> 2.1.0)
+      hashie (~> 4.1.0)
+      htmlentities
+      liquid
+      lutaml-model
+      lutaml-path
+      lutaml-xsd
+      nokogiri (~> 1.10)
+      parslet (~> 2.0.0)
+      ruby-graphviz (~> 1.2)
+      thor (~> 1.0)
+      xmi (~> 0.3.20)
+    lutaml-hal (0.1.10)
+      faraday (~> 2.0)
+      faraday-follow_redirects (~> 0.3)
+      lutaml-model
+      rainbow (~> 3.0)
+    lutaml-model (0.7.7)
+      moxml (>= 0.1.2)
+      thor
+    lutaml-path (0.1.0)
+      parslet
+    lutaml-xsd (1.0.4)
+      lutaml-model (~> 0.7)
+      zeitwerk
+    marcel (1.0.4)
+    matrix (0.4.3)
+    mechanize (2.14.0)
+      addressable (~> 2.8)
+      base64
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.3)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nkf
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
+    memo_wise (1.13.0)
+    metanorma (2.3.2)
+      asciidoctor
+      concurrent-ruby
+      fontist (>= 2.1.2)
+      htmlentities
+      isodoc (>= 3.0.0)
+      marcel
+      metanorma-taste (~> 1.0.0)
+      mn2pdf (~> 2)
+      nokogiri
+      relaton-cli
+    metanorma-bipm (2.8.1)
+      metanorma-generic (~> 3.3.0)
+      metanorma-iso (~> 3.3.1)
+    metanorma-cc (2.8.1)
+      metanorma-generic (~> 3.3.0)
+    metanorma-cli (1.15.1)
+      git (~> 2.0)
+      liquid (~> 5)
+      lutaml-model
+      metanorma (~> 2.3.0)
+      metanorma-bipm (~> 2.8.0)
+      metanorma-cc (~> 2.8.0)
+      metanorma-generic (~> 3.3.0)
+      metanorma-iec (~> 2.8.0)
+      metanorma-ieee (~> 1.6.0)
+      metanorma-ietf (~> 3.7.0)
+      metanorma-iho (~> 1.3.0)
+      metanorma-iso (~> 3.3.1)
+      metanorma-itu (~> 2.8.0)
+      metanorma-jis (~> 1.0.0)
+      metanorma-ogc (~> 2.9.0)
+      metanorma-plateau (~> 1.2.0)
+      metanorma-ribose (~> 2.8.0)
+      metanorma-standoc (~> 3.3.1)
+      mnconvert
+      relaton-cli (>= 0.8.2)
+      socksify
+      suma (~> 0.2.0)
+    metanorma-generic (3.3.0)
+      metanorma-standoc (~> 3.3.1)
+    metanorma-iec (2.8.1)
+      metanorma-iso (~> 3.3.1)
+      pubid
+    metanorma-ieee (1.6.4)
+      metanorma-standoc (~> 3.3.1)
+      mnconvert (~> 1.20)
+      pubid
+    metanorma-ietf (3.7.1)
+      metanorma-ietf-data
+      metanorma-standoc (~> 3.3.1)
+      relaton-render
+    metanorma-ietf-data (0.2.0)
+    metanorma-iho (1.3.1)
+      metanorma-generic (~> 3.3.0)
+    metanorma-iso (3.3.1)
+      metanorma-standoc (~> 3.3.1)
+      mnconvert (~> 1.14)
+      pubid
+      tokenizer (~> 0.3.0)
+    metanorma-itu (2.8.4)
+      metanorma-standoc (~> 3.3.1)
+      pubid
+      twitter_cldr (>= 3.0.0)
+      tzinfo-data
+    metanorma-jis (1.0.4)
+      japanese_calendar (~> 0)
+      metanorma-iso (~> 3.3.1)
+      pubid
+    metanorma-ogc (2.9.1)
+      iso-639
+      metanorma-standoc (~> 3.3.0)
+    metanorma-plateau (1.2.4)
+      metanorma-jis (~> 1.0.3)
+      pubid
+    metanorma-plugin-glossarist (0.2.11)
+      asciidoctor
+      glossarist (~> 2.3.7)
+      liquid
+      metanorma-utils (~> 2.0)
+    metanorma-plugin-lutaml (0.7.38)
+      asciidoctor
+      coradoc (~> 1.1)
+      expressir (~> 2.1)
+      isodoc
+      liquid
+      lutaml (~> 0.9)
+      ogc-gml (~> 1.0.0)
+      relaton-cli
+    metanorma-plugin-plantuml (1.0.9)
+      asciidoctor
+      isodoc
+    metanorma-ribose (2.8.1)
+      metanorma-generic (~> 3.3.0)
+    metanorma-standoc (3.3.1)
+      addressable (~> 2.8.0)
+      asciidoctor (~> 2.0.0)
+      concurrent-ruby
+      crass (~> 1.0.0)
+      iev (~> 0.3.5)
+      isodoc (~> 3.4.0)
+      metanorma (>= 1.6.0)
+      metanorma-plugin-glossarist (~> 0.2.3)
+      metanorma-plugin-lutaml (~> 0.7.31)
+      metanorma-plugin-plantuml (~> 1.0.0)
+      metanorma-utils (~> 2.0.1)
+      png_conform (~> 0.1.0)
+      relaton-cli (~> 1.20.0)
+      relaton-iev (~> 1.2.0)
+      ruby-jing
+      svg_conform (~> 0.1.0)
+    metanorma-taste (1.0.0)
+      lutaml-model (~> 0.7)
+    metanorma-utils (2.0.3)
+      asciidoctor (>= 2)
+      concurrent-ruby
+      csv
+      htmlentities (~> 4.3.4)
+      nokogiri (>= 1.11)
+      sterile (~> 1.0.14)
+      uuidtools
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0224)
+    mini_portile2 (2.8.9)
+    minitest (6.0.2)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    mml (2.0.3)
+      lutaml-model
+      moxml
+    mn-requirements (0.5.8)
+      isodoc-i18n (>= 1.2.0)
+      metanorma-utils (>= 2.0.0)
+      relaton-render (>= 1.0.0)
+    mn2pdf (2.46)
+    mnconvert (1.80.0)
+    moxml (0.1.10)
+    multi_json (1.15.0)
+    net-ftp (0.1.4)
+      net-protocol
+      time
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
+    net-protocol (0.2.2)
+      timeout
+    nkf (0.2.0)
+    nokogiri (1.18.10)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-musl)
+      racc (~> 1.4)
+    nokogiri-styles (0.1.2)
+      nokogiri
+    octokit (4.25.1)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    ogc-gml (1.0.4)
+      lutaml-model (~> 0.7)
+      nokogiri
+    openssl (3.3.2)
+    optout (0.0.2)
+    oscal (0.1.1)
+      yaml
+    ox (2.14.23)
+      bigdecimal (>= 3.0)
+    paint (2.3.0)
+    parallel (1.27.0)
+    parslet (2.0.0)
+    plane1converter (0.0.1)
+    plist (3.7.2)
+    plurimath (0.9.11)
+      bigdecimal
+      lutaml-model
+      mml
+      ox
+      parslet
+      thor
+      unitsml
+    png_conform (0.1.3)
+      bindata (~> 2.5)
+      lutaml-model (~> 0.7)
+      paint (~> 2.3)
+      thor (~> 1.4)
+    premailer (1.28.0)
+      addressable
+      css_parser (>= 1.19.0)
+      htmlentities (>= 4.0.0)
+    prism (1.9.0)
+    process_executer (1.3.0)
+    pubid (1.15.6)
+      pubid-bsi (= 1.15.6)
+      pubid-ccsds (= 1.15.6)
+      pubid-cen (= 1.15.6)
+      pubid-core (= 1.15.6)
+      pubid-etsi (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-ieee (= 1.15.6)
+      pubid-iso (= 1.15.6)
+      pubid-itu (= 1.15.6)
+      pubid-jis (= 1.15.6)
+      pubid-nist (= 1.15.6)
+      pubid-plateau (= 1.15.6)
+    pubid-bsi (1.15.6)
+      parslet
+      pubid-cen (= 1.15.6)
+      pubid-core (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-iso (= 1.15.6)
+    pubid-ccsds (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-cen (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+      pubid-iec (= 1.15.6)
+      pubid-iso (= 1.15.6)
+    pubid-core (1.15.6)
+      parslet
+    pubid-etsi (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-iec (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-ieee (1.15.6)
+      parslet (~> 2.0.0)
+      pubid-iso (= 1.15.6)
+    pubid-iso (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-itu (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-jis (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    pubid-nist (1.15.6)
+      lightly
+      nokogiri
+      parslet
+      pubid-core (= 1.15.6)
+      rubyzip
+      thor
+    pubid-plateau (1.15.6)
+      parslet
+      pubid-core (= 1.15.6)
+    public_suffix (7.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rchardet (1.10.0)
+    rdf (3.3.1)
+      bcp47_spec (~> 0.2)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-turtle (3.3.0)
+      ebnf (~> 2.4)
+      rdf (~> 3.3)
+    relaton (1.20.2)
+      relaton-3gpp (~> 1.20.0)
+      relaton-bipm (~> 1.20.0)
+      relaton-bsi (~> 1.20.0)
+      relaton-calconnect (~> 1.20.0)
+      relaton-ccsds (~> 1.20.2)
+      relaton-cen (~> 1.20.0)
+      relaton-cie (~> 1.20.0)
+      relaton-doi (~> 1.20.0)
+      relaton-ecma (~> 1.20.0)
+      relaton-etsi (~> 1.20.0)
+      relaton-gb (~> 1.20.0)
+      relaton-iana (~> 1.20.0)
+      relaton-iec (~> 1.20.3)
+      relaton-ieee (~> 1.20.0)
+      relaton-ietf (~> 1.20.0)
+      relaton-iho (~> 1.20.0)
+      relaton-isbn (~> 1.20.0)
+      relaton-iso (~> 1.20.0)
+      relaton-itu (~> 1.20.0)
+      relaton-jis (~> 1.20.0)
+      relaton-nist (~> 1.20.0)
+      relaton-oasis (~> 1.20.0)
+      relaton-ogc (~> 1.20.0)
+      relaton-omg (~> 1.20.0)
+      relaton-plateau (~> 1.20.0)
+      relaton-un (~> 1.20.0)
+      relaton-w3c (~> 1.20.0)
+      relaton-xsf (~> 1.20.0)
+    relaton-3gpp (1.20.0)
+      csv
+      net-ftp (~> 0.1.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-bib (1.20.7)
+      addressable
+      bibtex-ruby
+      htmlentities
+      iso639
+      nokogiri (~> 1.18.3)
+      relaton-logger (~> 0.2.0)
+    relaton-bipm (1.20.4)
+      faraday (~> 2.7.0)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.2)
+      rubyzip (~> 2.3.0)
+    relaton-bsi (1.20.1)
+      algolia (~> 2.3.0)
+      faraday-net_http_persistent (~> 2.0)
+      graphql (~> 2.3)
+      graphql-client (~> 0.23)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-calconnect (1.20.1)
+      faraday (~> 2.7.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-ccsds (1.20.3)
+      mechanize (~> 2.10)
+      pubid-ccsds (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.17)
+    relaton-cen (1.20.2)
+      mechanize (~> 2.10)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-cie (1.20.1)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-cli (1.20.6)
+      liquid (~> 5)
+      relaton (~> 1.20.2)
+      thor
+      thor-hollaback
+    relaton-core (0.0.7)
+      relaton-logger (~> 0.2.0)
+    relaton-doi (1.20.1)
+      faraday (~> 2.7)
+      relaton-bib (~> 1.20.0)
+      relaton-bipm (~> 1.20.0)
+      relaton-ieee (~> 1.20.0)
+      relaton-ietf (~> 1.20.0)
+      relaton-nist (~> 1.20.0)
+    relaton-ecma (1.20.1)
+      mechanize (~> 2.10)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.4)
+    relaton-etsi (1.20.2)
+      csv (~> 3.0)
+      mechanize (~> 2.8)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.7)
+    relaton-gb (1.20.2)
+      cnccs (~> 0.1.1)
+      connection_pool (~> 2.4.0)
+      csv (~> 3.0)
+      gb-agencies (~> 0.0.1)
+      mechanize (~> 2.10)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-iana (1.20.0)
+      faraday (~> 2.7.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-iec (1.20.3)
+      addressable
+      base64
+      mechanize (~> 2.8)
+      pubid-iec (~> 1.15.4)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+      rubyzip
+    relaton-ieee (1.20.2)
+      faraday (~> 2.7.0)
+      ieee-idams (~> 0.2.14)
+      mini_portile2 (~> 2.8.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+      rubyzip (~> 2.3.0)
+    relaton-ietf (1.20.0)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.3)
+    relaton-iev (1.2.1)
+      htmlentities (~> 4.3.4)
+      nokogiri (>= 1.13.0)
+      relaton (>= 1.15)
+      uuidtools
+    relaton-iho (1.20.4)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-index (0.2.20)
+      openssl (~> 3.3.2)
+      pubid-core (~> 1.15.6)
+      relaton-logger (~> 0.2.0)
+      rubyzip (~> 2.3.0)
+    relaton-isbn (1.20.1)
+      relaton-bib (~> 1.20.0)
+    relaton-iso (1.20.1)
+      openssl (>= 3.3.2)
+      pubid-iso (~> 1.15.0)
+      relaton-index (~> 0.2.17)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-iso-bib (1.20.0)
+      isoics (~> 0.1.6)
+      relaton-bib (~> 1.20.0)
+    relaton-itu (1.20.4)
+      mechanize (~> 2.10)
+      parslet (~> 2.0.0)
+      relaton-bib (~> 1.20.0)
+      relaton-core (~> 0.0.6)
+      relaton-index (~> 0.2.0)
+    relaton-jis (1.20.0)
+      mechanize (~> 2.10)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-logger (0.2.3)
+      logger (~> 1.6)
+    relaton-nist (1.20.3)
+      base64
+      loc_mods (~> 0.2.0)
+      pubid (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+      rubyzip
+    relaton-oasis (1.20.0)
+      mechanize (~> 2.10)
+      multi_json (~> 1.15.0)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    relaton-ogc (1.20.1)
+      faraday (~> 2.7.0)
+      relaton-index (~> 0.2.0)
+      relaton-iso-bib (~> 1.20.0)
+    relaton-omg (1.20.1)
+      base64
+      mechanize (~> 2.8)
+      relaton-bib (~> 1.20.0)
+    relaton-plateau (1.20.0)
+      base64
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.12)
+      relaton-logger (~> 0.2.0)
+    relaton-render (1.0.4)
+      base64
+      bigdecimal
+      isodoc-i18n (~> 1.4.0)
+      liquid (~> 5)
+      metanorma-utils (~> 2)
+      nokogiri
+      relaton-bib (>= 1.20.0)
+      twitter_cldr
+      tzinfo-data
+    relaton-un (1.20.1)
+      addressable (~> 2.8.0)
+      faraday (~> 2.7.0)
+      http-cookie (~> 1.0.5)
+      relaton-bib (~> 1.20.0)
+    relaton-w3c (1.20.1)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.8)
+      w3c_api (~> 0.1.3)
+    relaton-xsf (1.20.0)
+      mechanize (~> 2.10)
+      relaton-bib (~> 1.20.0)
+      relaton-index (~> 0.2.0)
+    reverse_markdown (2.1.1)
+      nokogiri
+    rexml (3.4.4)
+    roman-numerals (0.3.0)
+    rouge (4.7.0)
+    ruby-graphviz (1.2.5)
+      rexml
+    ruby-jing (0.0.3)
+      optout (>= 0.0.2)
+    ruby-ole (1.2.13.1)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    rubyntlm (0.6.5)
+      base64
+    rubyzip (2.3.2)
+    sawyer (0.9.3)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
+    scanf (1.0.0)
+    securerandom (0.4.1)
+    sequel (5.102.0)
+      bigdecimal
+    seven-zip (1.4.2)
+    socksify (1.8.1)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-aarch64-linux)
+    sqlite3 (1.7.3-arm-linux)
+    sqlite3 (1.7.3-arm64-darwin)
+    sqlite3 (1.7.3-x86-linux)
+    sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
+    sterile (1.0.26)
+      nokogiri (>= 1.11.7)
+    strscan (3.1.7)
+    suma (0.2.4)
+      expressir (~> 2.1, >= 2.1.29)
+      glossarist (~> 2.3.7)
+      lutaml-model (~> 0.7)
+      metanorma (~> 2.3)
+      plurimath
+      ruby-progressbar
+      rubyzip (~> 2.3)
+      table_tennis
+      thor (>= 0.20)
+    svg_conform (0.1.11)
+      lutaml-model (~> 0.7)
+      moxml (~> 0.1, >= 0.1.10)
+      table_tennis
+      thor
+    sxp (2.0.0)
+      matrix (~> 0.4)
+      rdf (~> 3.3)
+    sys-proctable (1.3.0)
+      ffi (~> 1.1)
+    table_tennis (0.0.7)
+      csv (~> 3.3)
+      ffi (~> 1.17)
+      memo_wise (~> 1.11)
+      paint (~> 2.3)
+      unicode-display_width (~> 3.1)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
+    thor (1.5.0)
+    thor-hollaback (0.2.1)
+      hollaback (~> 0.1)
+      thor (>= 0.19.1)
+    thread_safe (0.3.6)
+    time (0.4.2)
+      date
+    timeout (0.6.0)
+    tokenizer (0.3.0)
+    twitter_cldr (6.14.0)
+      base64
+      camertron-eprun
+      cldr-plurals-runtime-rb (~> 1.1)
+      tzinfo
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.3)
+      tzinfo (>= 1.0.0)
+    unibuf (0.1.2)
+      bindata (~> 2.5)
+      lutaml-model (~> 0.7)
+      parslet (~> 2.0)
+      thor (~> 1.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    unicode-types (1.11.0)
+    unitsdb (2.1.1)
+      lutaml-model (~> 0.7)
+      rdf (~> 3.1)
+      rdf-turtle (~> 3.1)
+      rubyzip (~> 2.3)
+      terminal-table
+      thor (~> 1.0)
+    unitsml (0.5.1)
+      htmlentities
+      lutaml-model (~> 0.7.6)
+      mml
+      parslet
+      unitsdb (~> 2.0)
+    uri (1.1.1)
+    uuidtools (3.0.0)
+    vectory (0.8.2)
+      base64
+      emf2svg
+      image_size (>= 3.2.0)
+      marcel (~> 1.0)
+      nokogiri (~> 1.14)
+      thor (~> 1.0)
+    w3c_api (0.1.7)
+      faraday
+      faraday-follow_redirects
+      lutaml-hal (~> 0.1.10)
+      rainbow
+      thor
+    webrick (1.9.2)
+    webrobots (0.1.2)
+    word-to-markdown (1.1.9)
+      cliver (~> 0.3)
+      descriptive_statistics (~> 2.5)
+      nokogiri-styles (~> 0.1)
+      premailer (~> 1.8)
+      reverse_markdown (>= 1, < 3)
+      sys-proctable (~> 1.0)
+    xmi (0.3.21)
+      lutaml-model (~> 0.7)
+      nokogiri
+    yaml (0.4.0)
+    zeitwerk (2.7.5)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  metanorma-cli (= 1.15.1)
+
+BUNDLED WITH
+   2.6.9


### PR DESCRIPTION
## Problem

`Gemfile`/`Gemfile.lock.archived` files for v1.15.0 and v1.15.1 were never committed to the repo. The CI workflow extracted them to `~/.mnenv/versions/data/gemfile/` instead of the repository directory due to a bug in mnenv (see metanorma/mnenv#9).

## Fix

Extract the missing files directly from `metanorma/metanorma` Docker images on Docker Hub and add them to the repo:
- `data/gemfile/v1.15.0/Gemfile`
- `data/gemfile/v1.15.0/Gemfile.lock.archived`
- `data/gemfile/v1.15.1/Gemfile`
- `data/gemfile/v1.15.1/Gemfile.lock.archived`

## Root Cause

`GemfileVersion#data_dir` ignored the `--data-dir` CLI option, always resolving to `~/.mnenv/versions/data/gemfile/`. The `Repository` class correctly used `--data-dir` for YAML read/write, but file extraction went to the wrong path. Fixed in metanorma/mnenv#9.

Fixes metanorma/versions#26

Depends on: metanorma/mnenv#9 (to prevent future recurrence)