### PR TITLE
Add optional release_provenance + rubygems_created_at fields

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -82,6 +82,29 @@ Additional fields per source:
 * **Chocolatey** - `package_name`, `is_pre_release`
 * **Binary** - `tag_name`, `html_url`, `platforms` (array with `name`, `arch`, `variant`, `format`, `filename`)
 
+=== Optional provenance fields
+
+Any version object may carry the following optional fields:
+
+* `rubygems_created_at` — the RubyGems.org `created_at` timestamp for the underlying `metanorma-cli` gem release, for correlation with the channel-specific `published_at`.
+* `release_provenance` — a sub-hash describing how the `metanorma-cli` release was published:
++
+[source,yaml]
+----
+release_provenance:
+  published_via: workflow                                                       # 'workflow' | 'manual' | 'unknown'
+  workflow_run_id: 28325008101                                                  # GitHub Actions run-id when 'workflow', null otherwise
+  workflow_url: https://github.com/metanorma/metanorma-cli/actions/runs/28325008101
+  annotation: 'metanorma-cli release workflow (normal path)'
+----
+
+Population paths:
+
+* Forward — the `metanorma/ci` `rubygems-release.yml` post-publish step writes the field at release time (planned, tracked in metanorma/ci#367 follow-up).
+* Retroactive — data commits annotate known anomalies (e.g., manual pushes during infrastructure work).
+
+Consumers unaware of these fields safely ignore them (mnenv uses `YAML.safe_load` with selective field access).
+
 == Usage
 
 === Using Gemfile files for a version

--- a/data/gemfile/versions.yaml
+++ b/data/gemfile/versions.yaml
@@ -797,15 +797,33 @@ versions:
   gemfile_exists: true
   gemfile_path: v1.16.6/Gemfile
   gemfile_lock_path: v1.16.6/Gemfile.lock.archived
+  rubygems_created_at: '2026-06-28T14:16:23Z'
+  release_provenance:
+    published_via: workflow
+    workflow_run_id: 28325008101
+    workflow_url: https://github.com/metanorma/metanorma-cli/actions/runs/28325008101
+    annotation: 'metanorma-cli release workflow (normal path)'
 - version: 1.16.8
   published_at: '2026-07-07T06:09:15Z'
   parsed_at: '2026-07-09T00:53:34Z'
   gemfile_exists: true
   gemfile_path: v1.16.8/Gemfile
   gemfile_lock_path: v1.16.8/Gemfile.lock.archived
+  rubygems_created_at: '2026-07-07T01:03:18Z'
+  release_provenance:
+    published_via: manual
+    workflow_run_id: null
+    workflow_url: null
+    annotation: 'OIDC/Trusted-Publisher rework period, manual gem push (2026-08-02 ci#367 investigation)'
 - version: 1.16.9
   published_at: '2026-07-21T14:39:57Z'
   parsed_at: '2026-08-03T00:50:38Z'
   gemfile_exists: true
   gemfile_path: v1.16.9/Gemfile
   gemfile_lock_path: v1.16.9/Gemfile.lock.archived
+  rubygems_created_at: '2026-07-20T15:41:35Z'
+  release_provenance:
+    published_via: manual
+    workflow_run_id: null
+    workflow_url: null
+    annotation: 'OIDC/Trusted-Publisher rework period, manual gem push (2026-08-02 ci#367 investigation)'


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/367

## Why

**Problem.** The green-means-published failsafe dashboard can't trust rubygems `created_at` alone — it doesn't distinguish workflow-published from manual `gem push`. Both paths landed metanorma-cli releases in July during the OIDC/Trusted-Publisher rework.

**Fix.** Add an optional `release_provenance` field per version entry so the dashboard can tell them apart. Also add `rubygems_created_at` as a correlation datum (the register's existing `published_at` is the Docker-channel timestamp, not the rubygems one).

**Why this register.** You pointed opoudjis at `metanorma/versions` as the aggregate-release-metadata layer. Version numbering is 1:1 with metanorma-cli releases. Correct architectural home.

**Scope.** Two optional fields (non-breaking). Three annotated versions (v1.16.6 workflow, v1.16.8/9 manual). One README subsection. Backwards-compat verified against mnenv.

## What changes

* `data/gemfile/versions.yaml` — three targeted annotations on existing v1.16.6 / v1.16.8 / v1.16.9 entries. Existing fields untouched.
* `README.adoc` — new subsection under *Version object structure* documenting the two optional fields, semantics, population paths, consumer-tolerance guarantee.

Annotations applied:

| Version | `published_via` | Evidence |
|---|---|---|
| v1.16.6 | `workflow` | `release` workflow run 28325008101 brackets rubygems `created_at` (workflow 14:14:41Z–14:16:27Z, rubygems 14:16:23Z) — normal pattern positive control |
| v1.16.8 | `manual` | rubygems `created_at` 2026-07-07T01:03:18Z; `release` workflow ran 2026-07-07T02:51Z — ~1h48m *after* gem was already on RubyGems |
| v1.16.9 | `manual` | rubygems `created_at` 2026-07-20T15:41:35Z; version-bump commit `18b03083` at 15:41:10Z (25s earlier); zero metanorma-cli workflow runs 2026-07-20T09:00Z–2026-07-21T07:09Z; do-release ran ~14h later with all publish steps SKIPPED by the idempotent-publish-guard |

## Schema

```yaml
release_provenance:
  published_via: workflow                                                        # 'workflow' | 'manual' | 'unknown'
  workflow_run_id: 28325008101                                                   # numeric GitHub run-id when 'workflow', null otherwise
  workflow_url: https://github.com/metanorma/metanorma-cli/actions/runs/28325008101
  annotation: 'metanorma-cli release workflow (normal path)'
```

## Backwards-compatibility

`metanorma/mnenv` (`lib/mnenv/repository.rb`) parses with `YAML.safe_load(..., permitted_classes: [Time, Symbol, Date])`. **`safe_load` restricts CLASSES, not FIELDS** — unknown fields parse into the hash and are silently ignored. Consumer API (`find`, `all`, `latest`) is selective on fields, not enumerate-and-reject. actions-mn: same shape per README. Verified against current mnenv main.

## Bounded retroactive scope — why only three rows

Not touching the other 130+ versions. Each of the three annotations is verifiable against timing evidence directly; correlation-heuristic across all history has the same overkill / blast-radius profile as backfill-all and is deliberately avoided.

**v1.16.7 note:** deliberately not annotated. Categorised as an abortive release (release attempted during testing that went bad but landed on RubyGems anyway); no register entry exists to annotate and no backfill planned.

## Non-scope

* No consumer changes (mnenv, actions-mn, gem release workflows).
* No cron-discovery logic (blast-radius reasons above).
* No schema validation / test coverage (data + doc only, no logic).
* No forward-write mechanism — that's a follow-up PR against `metanorma/ci` `rubygems-release.yml` (necessary for ongoing coverage; depends on this schema landing).
* No changes to existing `published_at` semantics (still the Docker-channel timestamp, now explicit in docs).

## Follow-ups (separate PRs)

* `metanorma/ci` — post-publish provenance-write step in `rubygems-release.yml`.
* Failsafe green-dashboard consumer that reads `release_provenance.published_via` when raising alerts (ci#302 territory).

🤖
