### PR TITLE
release_provenance + rubygems_created_at + schema validation

### DIFF
--- a/.github/scripts/validate_versions.py
+++ b/.github/scripts/validate_versions.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate data/gemfile/versions.yaml against schemas/gemfile-versions.schema.json.
+
+Exits non-zero on any schema violation. Uses jsonschema (pip install jsonschema
+PyYAML referencing) — installed by the validate-versions workflow.
+
+Usage:
+    python3 .github/scripts/validate_versions.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator, FormatChecker
+from referencing import Registry, Resource
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCHEMA_DIR = REPO_ROOT / "schemas"
+DATA_FILE = REPO_ROOT / "data" / "gemfile" / "versions.yaml"
+ROOT_SCHEMA = SCHEMA_DIR / "gemfile-versions.schema.json"
+ENTRY_SCHEMA = SCHEMA_DIR / "gemfile-version.schema.json"
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def load_schema(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def build_registry() -> Registry:
+    """Register every schema under schemas/ by its $id, so $refs resolve."""
+    registry = Registry()
+    for path in SCHEMA_DIR.glob("*.schema.json"):
+        schema = load_schema(path)
+        registry = registry.with_resource(schema["$id"], Resource.from_contents(schema))
+    return registry
+
+
+def main() -> int:
+    if not DATA_FILE.exists():
+        print(f"missing data file: {DATA_FILE}", file=sys.stderr)
+        return 2
+    if not ROOT_SCHEMA.exists():
+        print(f"missing schema: {ROOT_SCHEMA}", file=sys.stderr)
+        return 2
+
+    root_schema = load_schema(ROOT_SCHEMA)
+    validator = Draft202012Validator(
+        root_schema,
+        registry=build_registry(),
+        format_checker=FormatChecker(),
+    )
+
+    data = load_yaml(DATA_FILE)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if not errors:
+        n = len(data.get("versions") or [])
+        print(f"OK — {n} version entries valid against {ROOT_SCHEMA.name}")
+        return 0
+
+    print(f"FAIL — {len(errors)} schema violation(s) in {DATA_FILE}:",
+          file=sys.stderr)
+    for err in errors:
+        loc = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        print(f"  {loc}: {err.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -1,0 +1,40 @@
+name: validate-versions
+
+# Validates data/gemfile/versions.yaml against schemas/gemfile-versions.schema.json
+# Catches typos, missing required fields, malformed timestamps, and shape drift
+# before they land on main. Per ci#367 (release_provenance schema).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - data/gemfile/versions.yaml
+      - schemas/**
+      - .github/scripts/validate_versions.py
+      - .github/workflows/validate-versions.yml
+  pull_request:
+    paths:
+      - data/gemfile/versions.yaml
+      - schemas/**
+      - .github/scripts/validate_versions.py
+      - .github/workflows/validate-versions.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install validator deps
+        run: pip install --no-input jsonschema==4.23.0 PyYAML==6.0.2
+
+      - name: Validate gemfile versions
+        run: python3 .github/scripts/validate_versions.py

--- a/README.adoc
+++ b/README.adoc
@@ -82,6 +82,44 @@ Additional fields per source:
 * **Chocolatey** - `package_name`, `is_pre_release`
 * **Binary** - `tag_name`, `html_url`, `platforms` (array with `name`, `arch`, `variant`, `format`, `filename`)
 
+=== Optional provenance fields
+
+Any version object may carry the following optional fields:
+
+* `rubygems_created_at` — the RubyGems.org `created_at` timestamp for the underlying `metanorma-cli` gem release, for correlation with the channel-specific `published_at`.
+* `release_provenance` — a sub-hash describing how the `metanorma-cli` release was published:
++
+[source,yaml]
+----
+release_provenance:
+  published_via: workflow                                                       # 'workflow' | 'manual' | 'unknown'
+  workflow_run_id: 28325008101                                                  # GitHub Actions run-id when 'workflow', null otherwise
+  workflow_url: https://github.com/metanorma/metanorma-cli/actions/runs/28325008101
+  annotation: 'metanorma-cli release workflow (normal path)'
+----
+
+Population paths:
+
+* Forward — the `metanorma/ci` `rubygems-release.yml` post-publish step writes the field at release time (planned, tracked in metanorma/ci#367 follow-up).
+* Retroactive — data commits annotate known anomalies (e.g., manual pushes during infrastructure work).
+
+Consumers unaware of these fields safely ignore them (mnenv uses `YAML.safe_load` with selective field access).
+
+=== Schema validation
+
+The shape of `data/gemfile/versions.yaml` is enforced by JSON Schemas under `schemas/`:
+
+* `schemas/gemfile-versions.schema.json` — top-level wrapper (metadata + versions[])
+* `schemas/gemfile-version.schema.json`  — one entry under versions[]
+
+Validated by `.github/scripts/validate_versions.py`, run from the `validate-versions` workflow on every PR touching the data file or schemas. Violations (typos, missing required fields, malformed timestamps) fail CI before merge.
+
+Run locally:
+
+ pip install jsonschema PyYAML referencing
+ python3 .github/scripts/validate_versions.py
+
+
 == Usage
 
 === Using Gemfile files for a version

--- a/data/gemfile/versions.yaml
+++ b/data/gemfile/versions.yaml
@@ -797,15 +797,33 @@ versions:
   gemfile_exists: true
   gemfile_path: v1.16.6/Gemfile
   gemfile_lock_path: v1.16.6/Gemfile.lock.archived
+  rubygems_created_at: '2026-06-28T14:16:23Z'
+  release_provenance:
+    published_via: workflow
+    workflow_run_id: 28325008101
+    workflow_url: https://github.com/metanorma/metanorma-cli/actions/runs/28325008101
+    annotation: 'metanorma-cli release workflow (normal path)'
 - version: 1.16.8
   published_at: '2026-07-07T06:09:15Z'
   parsed_at: '2026-07-09T00:53:34Z'
   gemfile_exists: true
   gemfile_path: v1.16.8/Gemfile
   gemfile_lock_path: v1.16.8/Gemfile.lock.archived
+  rubygems_created_at: '2026-07-07T01:03:18Z'
+  release_provenance:
+    published_via: manual
+    workflow_run_id: null
+    workflow_url: null
+    annotation: 'OIDC/Trusted-Publisher rework period, manual gem push (2026-08-02 ci#367 investigation)'
 - version: 1.16.9
   published_at: '2026-07-21T14:39:57Z'
   parsed_at: '2026-08-03T00:50:38Z'
   gemfile_exists: true
   gemfile_path: v1.16.9/Gemfile
   gemfile_lock_path: v1.16.9/Gemfile.lock.archived
+  rubygems_created_at: '2026-07-20T15:41:35Z'
+  release_provenance:
+    published_via: manual
+    workflow_run_id: null
+    workflow_url: null
+    annotation: 'OIDC/Trusted-Publisher rework period, manual gem push (2026-08-02 ci#367 investigation)'

--- a/schemas/gemfile-version.schema.json
+++ b/schemas/gemfile-version.schema.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/metanorma/versions/schemas/gemfile-version.schema.json",
+  "title": "Gemfile source version entry",
+  "description": "One entry under data/gemfile/versions.yaml::versions[]. Validates the per-version object shape; the top-level wrapper (metadata + versions[]) is validated separately.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "published_at",
+    "parsed_at",
+    "gemfile_exists",
+    "gemfile_path",
+    "gemfile_lock_path"
+  ],
+  "allOf": [
+    {
+      "if": { "properties": { "gemfile_exists": { "const": true } }, "required": ["gemfile_exists"] },
+      "then": {
+        "properties": {
+          "published_at": { "type": "string", "format": "date-time" },
+          "gemfile_path": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+/Gemfile$" },
+          "gemfile_lock_path": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+/Gemfile\\.lock\\.archived$" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "gemfile_exists": { "const": false } }, "required": ["gemfile_exists"] },
+      "then": {
+        "properties": {
+          "published_at": { "type": ["string", "null"] },
+          "gemfile_path": { "type": ["string", "null"] },
+          "gemfile_lock_path": { "type": ["string", "null"] }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "SemVer-ish version string, e.g. '1.16.9'."
+    },
+    "published_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 timestamp for the Docker-channel publication. Null when gemfile_exists is false."
+    },
+    "parsed_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp for when mnenv extracted this entry."
+    },
+    "gemfile_exists": {
+      "type": "boolean"
+    },
+    "gemfile_path": {
+      "type": ["string", "null"],
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+/Gemfile$",
+      "description": "Null when gemfile_exists is false."
+    },
+    "gemfile_lock_path": {
+      "type": ["string", "null"],
+      "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+/Gemfile\\.lock\\.archived$",
+      "description": "Null when gemfile_exists is false."
+    },
+    "rubygems_created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional. RubyGems.org created_at for the underlying metanorma-cli gem; distinct from published_at (which is the Docker channel)."
+    },
+    "release_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "published_via",
+        "workflow_run_id",
+        "workflow_url",
+        "annotation"
+      ],
+      "properties": {
+        "published_via": {
+          "type": "string",
+          "enum": ["workflow", "manual", "unknown"]
+        },
+        "workflow_run_id": {
+          "type": ["integer", "null"],
+          "description": "GitHub Actions run-id when published_via=='workflow', null otherwise."
+        },
+        "workflow_url": {
+          "type": ["string", "null"],
+          "format": "uri",
+          "description": "GitHub Actions run URL when published_via=='workflow', null otherwise."
+        },
+        "annotation": {
+          "type": "string",
+          "description": "Free-form note explaining the classification."
+        }
+      }
+    }
+  }
+}

--- a/schemas/gemfile-versions.schema.json
+++ b/schemas/gemfile-versions.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/metanorma/versions/schemas/gemfile-versions.schema.json",
+  "title": "Gemfile versions register",
+  "description": "Top-level shape of data/gemfile/versions.yaml.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["metadata", "versions"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generated_at", "source", "count", "latest_version"],
+      "properties": {
+        "generated_at": { "type": "string", "format": "date-time" },
+        "source": { "type": "string" },
+        "count": { "type": "integer", "minimum": 0 },
+        "latest_version": { "type": "string" }
+      }
+    },
+    "versions": {
+      "type": "array",
+      "items": { "$ref": "gemfile-version.schema.json" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #40. Consolidated rework — same feature, plus the schema-validation layer the original PR lacked.

### What lands

| Piece | Role |
|---|---|
| `data/gemfile/versions.yaml` | Optional `rubygems_created_at` + `release_provenance` on v1.16.6/8/9 (the original PR's annotations) |
| `schemas/gemfile-version.schema.json` | JSON Schema for one version entry |
| `schemas/gemfile-versions.schema.json` | JSON Schema for the top-level wrapper |
| `.github/scripts/validate_versions.py` | Validator script (Python + jsonschema + referencing) |
| `.github/workflows/validate-versions.yml` | CI workflow — runs validator on every PR touching the data or schemas |
| `README.adoc` | Schema-validation section + local-run instructions |

### Schema design

- `additionalProperties: false` catches typo'd field names (verified via negative test locally)
- Conditional validation via `allOf` / `if` / `then`:
  - When `gemfile_exists: true` → `published_at`, `gemfile_path`, `gemfile_lock_path` are required strings with patterns
  - When `gemfile_exists: false` → those fields may be null (matches real entries for versions mnenv couldn't extract)
- `release_provenance` sub-object has its own `additionalProperties: false` + required-field set
- `published_via` is enum `[workflow, manual, unknown]` (MECE)

### Forward-population status

The README's "Population paths" still notes the forward (post-publish writer) path as planned in ci#367. With schema validation now in place, that writer can be added with confidence — any malformed entry it produces will fail CI. The retroactive path (manual annotation of historical anomalies) is the only one used today.

### Test plan

- [x] `python3 .github/scripts/validate_versions.py` passes on current data — 134 entries valid
- [x] Negative test: adding `rubygemz_created_at` (typo) is rejected with `Additional properties are not allowed`
- [x] Conditional test: entries with `gemfile_exists: false` + null paths pass
- [ ] CI: `validate-versions` workflow on this PR
