### PR TITLE
fetch-gemfile: auto-merge material changes after CI passes

### DIFF
--- a/.github/workflows/fetch-gemfile.yml
+++ b/.github/workflows/fetch-gemfile.yml
@@ -87,6 +87,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Create Pull Request
+        id: create-pr
         if: steps.detect-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
@@ -108,3 +109,26 @@ jobs:
             ${{ steps.detect-changes.outputs.material_change == 'true' && 'material-change' || '' }}
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
+
+      # Auto-merge material changes once CI (validate-versions schema check)
+      # passes. Non-material changes stay as drafts for human triage.
+      # Consolidation target: ci#379 generic-automerge.yml reusable, so this
+      # block isn't duplicated across fetch-binary/chocolatey/homebrew/snap.
+      - name: Wait for checks and auto-merge
+        if: steps.detect-changes.outputs.material_change == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ steps.create-pr.outputs.pull-request-number }}"
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR created — skipping auto-merge"
+            exit 0
+          fi
+
+          echo "Waiting for checks on PR #$PR_NUMBER..."
+          if gh pr checks "$PR_NUMBER" --watch --interval 30; then
+            echo "All checks passed — merging."
+            gh pr merge "$PR_NUMBER" --squash --delete-branch
+          else
+            echo "::warning::checks failed on PR #$PR_NUMBER — leaving for manual review"
+          fi


### PR DESCRIPTION
## Summary

Closes the "why doesn't the bot PR auto-merge?" gap. Adds a wait-and-merge step that runs after `peter-evans/create-pull-request@v7` and squash-merges once `validate-versions` (the schema check from #42) passes.

### What lands

- New `id: create-pr` on the existing PR-creation step so its `pull-request-number` output is capturable.
- New "Wait for checks and auto-merge" step gated on `material_change == 'true'` (non-material stays draft for human triage — unchanged).
- Step watches `gh pr checks --watch --interval 30`, then `gh pr merge --squash --delete-branch`. On check failure, leaves the PR open with a `::warning::` rather than failing the workflow.

### Why only fetch-gemfile.yml

Applying the same block to fetch-binary/chocolatey/homebrew/snap would duplicate the wait-and-merge code 4 more times. The durable fix is the `generic-automerge.yml` reusable being designed in [metanorma/ci#379](https://github.com/metanorma/ci/issues/379). This PR is the immediate fix; the follow-up issue on ci covers the consolidation arc.

### Pre-existing PR #41

PR #41 is currently `CONFLICTING` (branched from pre-#42 main, before the schema annotations landed). After this PR merges, the next steps are:
1. Close #41 (and delete the `update/gemfiles` branch).
2. Trigger a manual `workflow_dispatch` run of `Fetch Gemfile`.
3. New run recreates the PR from current main, runs schema validation, auto-merges.

### Test plan

- [x] YAML parses
- [x] Diff is additive (no behaviour change when no changes detected)
- [ ] CI on this PR
- [ ] Post-merge: close #41, trigger manual run, observe auto-merge
