### PR TITLE
feat: consume generic-bot-pr-merge for all five fetch-*.yml bot PRs

### DIFF
--- a/.github/workflows/fetch-binary.yml
+++ b/.github/workflows/fetch-binary.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   fetch-binary:
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      material-change: ${{ steps.detect-changes.outputs.material_change }}
     runs-on: ubuntu-latest
 
     steps:
@@ -103,3 +106,13 @@ jobs:
             ${{ steps.detect-changes.outputs.material_change == 'true' && 'material-change' || '' }}
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
+
+  merge-pr:
+    needs: fetch-binary
+    if: >-
+      needs.fetch-binary.outputs.pr-number != '' &&
+      needs.fetch-binary.outputs.material-change == 'true' &&
+      needs.fetch-binary.result == 'success'
+    uses: metanorma/ci/.github/workflows/generic-bot-pr-merge.yml@main
+    with:
+      pr-number: ${{ needs.fetch-binary.outputs.pr-number }}

--- a/.github/workflows/fetch-chocolatey.yml
+++ b/.github/workflows/fetch-chocolatey.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   fetch-chocolatey:
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      material-change: ${{ steps.detect-changes.outputs.material_change }}
     runs-on: ubuntu-latest
 
     steps:
@@ -101,3 +104,13 @@ jobs:
             ${{ steps.detect-changes.outputs.material_change == 'true' && 'material-change' || '' }}
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
+
+  merge-pr:
+    needs: fetch-chocolatey
+    if: >-
+      needs.fetch-chocolatey.outputs.pr-number != '' &&
+      needs.fetch-chocolatey.outputs.material-change == 'true' &&
+      needs.fetch-chocolatey.result == 'success'
+    uses: metanorma/ci/.github/workflows/generic-bot-pr-merge.yml@main
+    with:
+      pr-number: ${{ needs.fetch-chocolatey.outputs.pr-number }}

--- a/.github/workflows/fetch-gemfile.yml
+++ b/.github/workflows/fetch-gemfile.yml
@@ -24,6 +24,9 @@ permissions:
 
 jobs:
   extract-gemfiles:
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      material-change: ${{ steps.detect-changes.outputs.material_change }}
     runs-on: ubuntu-latest
 
     steps:
@@ -110,25 +113,12 @@ jobs:
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
 
-      # Auto-merge material changes once CI (validate-versions schema check)
-      # passes. Non-material changes stay as drafts for human triage.
-      # Consolidation target: ci#379 generic-automerge.yml reusable, so this
-      # block isn't duplicated across fetch-binary/chocolatey/homebrew/snap.
-      - name: Wait for checks and auto-merge
-        if: steps.detect-changes.outputs.material_change == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER="${{ steps.create-pr.outputs.pull-request-number }}"
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR created — skipping auto-merge"
-            exit 0
-          fi
-
-          echo "Waiting for checks on PR #$PR_NUMBER..."
-          if gh pr checks "$PR_NUMBER" --watch --interval 30; then
-            echo "All checks passed — merging."
-            gh pr merge "$PR_NUMBER" --squash --delete-branch
-          else
-            echo "::warning::checks failed on PR #$PR_NUMBER — leaving for manual review"
-          fi
+  merge-pr:
+    needs: extract-gemfiles
+    if: >-
+      needs.extract-gemfiles.outputs.pr-number != '' &&
+      needs.extract-gemfiles.outputs.material-change == 'true' &&
+      needs.extract-gemfiles.result == 'success'
+    uses: metanorma/ci/.github/workflows/generic-bot-pr-merge.yml@main
+    with:
+      pr-number: ${{ needs.extract-gemfiles.outputs.pr-number }}

--- a/.github/workflows/fetch-homebrew.yml
+++ b/.github/workflows/fetch-homebrew.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   fetch-homebrew:
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      material-change: ${{ steps.detect-changes.outputs.material_change }}
     runs-on: ubuntu-latest
 
     steps:
@@ -101,3 +104,13 @@ jobs:
             ${{ steps.detect-changes.outputs.material_change == 'true' && 'material-change' || '' }}
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
+
+  merge-pr:
+    needs: fetch-homebrew
+    if: >-
+      needs.fetch-homebrew.outputs.pr-number != '' &&
+      needs.fetch-homebrew.outputs.material-change == 'true' &&
+      needs.fetch-homebrew.result == 'success'
+    uses: metanorma/ci/.github/workflows/generic-bot-pr-merge.yml@main
+    with:
+      pr-number: ${{ needs.fetch-homebrew.outputs.pr-number }}

--- a/.github/workflows/fetch-snap.yml
+++ b/.github/workflows/fetch-snap.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   fetch-snap:
+    outputs:
+      pr-number: ${{ steps.create-pr.outputs.pull-request-number }}
+      material-change: ${{ steps.detect-changes.outputs.material_change }}
     runs-on: ubuntu-latest
 
     steps:
@@ -125,3 +128,13 @@ jobs:
             ${{ steps.detect-changes.outputs.material_change == 'true' && 'material-change' || '' }}
           draft: ${{ steps.detect-changes.outputs.material_change == 'false' }}
           delete-branch: true
+
+  merge-pr:
+    needs: fetch-snap
+    if: >-
+      needs.fetch-snap.outputs.pr-number != '' &&
+      needs.fetch-snap.outputs.material-change == 'true' &&
+      needs.fetch-snap.result == 'success'
+    uses: metanorma/ci/.github/workflows/generic-bot-pr-merge.yml@main
+    with:
+      pr-number: ${{ needs.fetch-snap.outputs.pr-number }}


### PR DESCRIPTION
## Summary

Consumes [metanorma/ci#399](https://github.com/metanorma/ci/pull/399) (`generic-bot-pr-merge.yml`) across all five fetch workflows — completing ci#386.

### What changes

- `fetch-gemfile.yml`: the inline wait-and-merge block from versions#43 is **replaced** by the reusable (last inline copy deleted — one implementation, five consumers).
- `fetch-binary/chocolatey/homebrew/snap.yml`: get the reusable wired in (they never had automerge — their bot PRs previously sat for human merge indefinitely).

### Mechanics

Generator job exports `pr-number` + `material-change`; new `merge-pr` job calls the reusable gated on:
- `pr-number != ''` (no PR created → no merge)
- `material-change == 'true'` (**non-material PRs are drafts and cannot be merged** — this gate is required, not optional)
- generator `result == 'success'`

The reusable watches `gh pr checks --watch`, squash-merges on green, warns and leaves the PR open on red.

### Test plan

- [x] All five YAML parse
- [x] GH expressions verified intact (`${{ }}` — an f-string escaping bug was caught and fixed pre-commit)
- [ ] CI on this PR
- [ ] End-to-end proof: next scheduled run (or a manual dispatch with pending changes) creates a material PR and auto-merges — same behavior versions#43 already demonstrated for fetch-gemfile
